### PR TITLE
Automate data updates

### DIFF
--- a/.github/workflows/update_data.yaml
+++ b/.github/workflows/update_data.yaml
@@ -1,0 +1,25 @@
+name: Update GCS data
+
+on:
+  workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: yarn
+      - name: Setup gcloud and gsutil
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCLOUD_API_KEYFILE }}
+          export_default_credentials: true
+      - run: gcloud info
+      - name: Update GCS data
+        run: |
+          ./bin/update.sh

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```
 yarn
-bin/update-data.sh
+bin/update.sh
 ```
 
 ## Local preview
@@ -18,5 +18,3 @@ npx hot-server
 To view locally generated data, go to [localhost:3989/?local-data=true](http://localhost:3989/?local-data=true)
 
 **This is not an officially supported Google product**
-
-

--- a/bin/download.js
+++ b/bin/download.js
@@ -9,9 +9,12 @@ var rawdir = __dirname + '/../data-raw'
 
 
 function cloneRepo(){
+  if (!fs.existsSync(rawdir)){
+    execSync(`mkdir ${rawdir}`)
+  }
   if (!fs.existsSync(rawdir + '/open-covid-19-data')){
     console.log('cloning repo')
-    execSync(`cd ${rawdir} && git clone git@github.com:google-research/open-covid-19-data.git`)
+    execSync(`cd ${rawdir} && git clone https://github.com/google-research/open-covid-19-data.git`)
   } else {
     console.log('pulling repo')
     execSync(`cd ${rawdir}/open-covid-19-data && git pull`)
@@ -37,5 +40,3 @@ async function downloadZips(){
   execSync(`cd ${zipdir} && unzip '*.zip'`)
 }
 downloadZips()
-
-


### PR DESCRIPTION
This PR adds a github workflow that automates the data update process for this visualization.

The existing process to update data was to run the `bin/update.sh` script locally, using username/password credentials for gsutil authentication. Note that this doesn't modify the contents of the github repo; it only modifies the data in the Google Cloud Storage bucket `gs://uncertainty-over-space/combined`.

The changes here allow the github workflow to run the same script in the transient workflow environment. In particular, this requires using a JSON keyfile, stored as a github secret in this repository, for gsutil authentication. This JSON keyfile comes from a service account that has write access to the GCS bucket.

Right now, the workflow is set to run `on: workflow_dispatch`, which allows for triggering the workflow manually. We will want to change this to a cron schedule after testing.

**Changes:**
- Edit `bin/download.js` to handle the case where `data-raw` directory doesn't exist.
- Edit `bin/download.js` to use `https` to clone the github repo instead of `ssh`.
- Update README.md with correct name of update script.
- Add GCLOUD_API_KEYFILE secret containing JSON key that gsutil uses to authenticate.
- Add `.github/workflows/update_data.yaml` which defines the update workflow.