### PR TITLE
Add test workflow

### DIFF
--- a/.github/workflows/update_data.yaml
+++ b/.github/workflows/update_data.yaml
@@ -1,0 +1,10 @@
+name: Update GCS data
+
+on:
+  workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2


### PR DESCRIPTION
I'd like to test the `update_data.yaml` workflow that is in the `automate_updates` branch, but in order to test the workflow, the workflow needs to exist in `main`. (You can test the *version* that is in the branch, as long as the workflow *exists* in main.) This PR lets us merge in a skeleton workflow, so that we can test before merging #1.