### PR TITLE
Fix risk of leaking gcloud credential

### DIFF
--- a/.github/workflows/update_data.yaml
+++ b/.github/workflows/update_data.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           service_account_key: ${{ secrets.GCLOUD_API_KEYFILE }}
-          export_default_credentials: true
+          export_default_credentials: false
       - run: gcloud info
       - name: Update GCS data
         run: |


### PR DESCRIPTION
There is a security risk that when running the `update_data.yml` workflow, that the gcloud credential could get written out to a file. This happened in another repo under a failure case where the workflow didn't complete and wrote out the environment variables, which wrote the credential into a file and committed it. I think the risk of that happening is lower here because this workflow doesn't have a later step that writes to the repo, but it's still an unnecessary risk.

The fix is to set `export_default_credentials: false` instead of `export_default_credentials: true` in the `GoogleCloudPlatform/github-actions/setup-gcloud@master` step. Originally, I thought that `export_default_credentials: true` would be required for the github workflow to have access to the credential in the next steps, but that was not correct.

To test, I ran the workflow [manually](https://github.com/PAIR-code/covid19_symptom_dataset/actions/runs/465067388) and verified that it completed successfully.